### PR TITLE
Modernize asset loading for WordPress 6.8

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -11,27 +11,23 @@ function pp_admin_init() {
  * add admin_menu
  **********************************************************************/
 function pp_admin_menu() {
-	global $pp_option_page;
-	$pp_option_page = add_options_page( PP_APP_NAME . ' ' . pp__( 'Settings'), PP_APP_NAME, 'manage_options', strtolower( PP_APP_NAME ), 'pp_edit_settings' );
-	add_action( 'admin_print_scripts-' . $pp_option_page, 'pp_admin_headers' );
+        global $pp_option_page;
+        $pp_option_page = add_options_page( PP_APP_NAME . ' ' . pp__( 'Settings'), PP_APP_NAME, 'manage_options', strtolower( PP_APP_NAME ), 'pp_edit_settings' );
 }
+
 /***********************************************************************
- * print admin headers
+ * enqueue admin scripts
  **********************************************************************/
-function pp_admin_headers() {
-	 wp_enqueue_script( 'pp_admin_js' );
-}
-/***********************************************************************
- * print admin scripts
- **********************************************************************/
-function pp_admin_print_scripts(){
-	global $pp_settings;
-	echo '<script type="text/javascript">
-var PP_SETTINGS_UPLOAD_DIR = "' . site_url( '/' . $pp_settings[PP_SETTINGS_UPLOAD_DIR] . '/' ) . '";
-var PP_SETTINGS_WIDTH = \'' . $pp_settings[PP_SETTINGS_WIDTH] . '\';
-var PP_SETTINGS_HEIGHT = \'' . $pp_settings[PP_SETTINGS_HEIGHT] . '\';
-</script>
-';
+function pp_admin_enqueue_scripts( $hook ) {
+        global $pp_option_page, $pp_settings;
+        if ( $hook !== $pp_option_page ) {
+                return;
+        }
+        wp_enqueue_script( 'pp_admin_js' );
+        $inline_js  = 'var PP_SETTINGS_UPLOAD_DIR = "' . esc_js( site_url( '/' . $pp_settings[PP_SETTINGS_UPLOAD_DIR] . '/' ) ) . '";';
+        $inline_js .= "\nvar PP_SETTINGS_WIDTH = '" . esc_js( $pp_settings[PP_SETTINGS_WIDTH] ) . "';";
+        $inline_js .= "\nvar PP_SETTINGS_HEIGHT = '" . esc_js( $pp_settings[PP_SETTINGS_HEIGHT] ) . "';";
+        wp_add_inline_script( 'pp_admin_js', $inline_js );
 }
 /***********************************************************************
  * add tynymce plugin
@@ -77,11 +73,11 @@ function pp_uninstall() {
  * register actions
  **********************************************************************/
 if (is_admin()) {
-	add_action( 'admin_init', 'pp_admin_init' );
-	add_action( 'admin_menu', 'pp_admin_menu' );
-	add_action( 'admin_print_scripts', 'pp_admin_print_scripts' );
-	add_filter( 'contextual_help', 'pp_contextual_help', 10, 3 );
-	register_uninstall_hook( __FILE__, 'pp_uninstall' );
+        add_action( 'admin_init', 'pp_admin_init' );
+        add_action( 'admin_menu', 'pp_admin_menu' );
+        add_action( 'admin_enqueue_scripts', 'pp_admin_enqueue_scripts' );
+        add_filter( 'contextual_help', 'pp_contextual_help', 10, 3 );
+        register_uninstall_hook( __FILE__, 'pp_uninstall' );
 }
 /***********************************************************************
  * get wp root directory

--- a/panopress.php
+++ b/panopress.php
@@ -4,6 +4,8 @@ Plugin Name: PanoPress
 Plugin URI:  http://www.panopress.org/
 Description: Embed Flash & HTML5 360° Panoramas & Virtual Tours, 360° Video, Gigapixel Panoramas etc, created using KRPano, Pano2VR, PanoTour Pro, Flashificator, Saladoplayer, and similar panorama applications  on your WordPress site using a simple shortcode.
 Version:     1.3
+Requires at least: 3.0
+Tested up to: 6.8
 Author:      <a href="http://www.omercalev.com">Omer Calev</a> & <a href="http://www.samrohn.com">Sam Rohn</a>
 ************************************************************************
 	Copyright 2011-2014 by the authors.
@@ -212,43 +214,31 @@ function pp_get_viewr_name ( $xml_url ) {
 	return array( 'status' => $status , 'content' => $content );
 }
 /**
- * inject code into head
+ * Enqueue frontend scripts and styles.
  **/
-function pp_headers() {
-global $pp_settings;
-$oppp = $pp_settings[PP_SETTINGS_OPPP] == PP_OPPP_ALL || ( $pp_settings[PP_SETTINGS_OPPP] == PP_OPPP_MOBILE && PP_USER_AGENT_MODILE )? 'true' : 'false';
+function pp_enqueue_assets() {
+        global $pp_settings;
+        $oppp = $pp_settings[PP_SETTINGS_OPPP] == PP_OPPP_ALL || ( $pp_settings[PP_SETTINGS_OPPP] == PP_OPPP_MOBILE && PP_USER_AGENT_MODILE ) ? 'true' : 'false';
 
-// add resize default to pp settings
-$pp_settings[PP_SETTINGS_PANOBOX][PB_SETTINGS_RESIZE] = 1;
+        // add resize default to pp settings
+        $pp_settings[PP_SETTINGS_PANOBOX][PB_SETTINGS_RESIZE] = 1;
 
-echo '<!-- ' . PP_APP_NAME . ' [' . PP_APP_VERSION . '] -->
-<script type="text/javascript">
-pp_oppp=' . $oppp . ';
-pb_options=' . json_encode( $pp_settings[PP_SETTINGS_PANOBOX] ) . ';
-</script>
-<script type="text/javascript"  src="' . plugins_url( '/js/panopress.js',  __FILE__  )  . '?v='. PP_APP_VERSION .'"></script>
-<link rel="stylesheet" type="text/css" media="all" href="' . plugins_url( '/css/panopress.css?v='. PP_APP_VERSION ,  __FILE__  )  . '" />	
-';
-if( strlen(  $pp_settings[PP_SETTINGS_CSS] ) > 1 ) {
-echo '<style type="text/css">
-' .  $pp_settings[PP_SETTINGS_CSS] . '
-</style>
-';
-}
-echo '<!-- /' . PP_APP_NAME . ' -->
-';
-}
-add_action( 'wp_head', 'pp_headers' );
+        wp_enqueue_script( 'panopress-js', plugins_url( '/js/panopress.js', __FILE__ ), array(), PP_APP_VERSION, true );
+        wp_enqueue_style( 'panopress-css', plugins_url( '/css/panopress.css', __FILE__ ), array(), PP_APP_VERSION );
 
-/**
- * inject code into footer
- **/
-function pp_footer() {
-	if( PP_PANOBOX_IMAGES || $pp_settings[PP_SETTINGS_PANOBOX][PB_SETTINGS_GALLERIES] ) {
-		echo '<script type="text/javascript">panopress.imagebox();</script>';
-	}
+        $inline_js = "pp_oppp={$oppp};\n";
+        $inline_js .= 'pb_options=' . json_encode( $pp_settings[PP_SETTINGS_PANOBOX] ) . ';';
+        wp_add_inline_script( 'panopress-js', $inline_js, 'before' );
+
+        if ( strlen( $pp_settings[PP_SETTINGS_CSS] ) > 1 ) {
+                wp_add_inline_style( 'panopress-css', $pp_settings[PP_SETTINGS_CSS] );
+        }
+
+        if ( PP_PANOBOX_IMAGES || $pp_settings[PP_SETTINGS_PANOBOX][PB_SETTINGS_GALLERIES] ) {
+                wp_add_inline_script( 'panopress-js', 'panopress.imagebox();' );
+        }
 }
-add_action( 'wp_footer', 'pp_footer');
+add_action( 'wp_enqueue_scripts', 'pp_enqueue_assets' );
 
 /**
  * override gallery_shortcode and change link to 'file'

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: omercalev, sam rohn
 Donate link: http://panopress.org
 Tags:  360, 360 degree Photography, 360 degree Panorama, 360 degree Video, 360 Panorama, 360 Photography, 360 Video, 360Cities, CuTy, EasyPano, FFP, Flash, Flash Panorama Player, Flashificator, HTML5, Gigapixel, Gigapan, Lightbox, Kolor, KRPano, Media, Multires, Object Movie, Object VR, Object2VR, Pano, Pano2VR, Panobox, PanoPress, Panorama, Panoramic, Panotour, Panotour Pro, Photo, Photography, Photosynth, PTGui, QuickTime VR, QTVR, Responsive, Salado, Saladoplayer, Shortcode, Silverlight, Tourweaver, Tourwrist, Virtual Tour, Virtual Reality, ViewAt, VR, WebGL, Zoomify
 Requires at least: 3.0.0
-Tested up to: 4.7
+Tested up to: 6.8
 Stable tag: 1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- use WordPress enqueue APIs for front-end assets
- load admin scripts via `admin_enqueue_scripts`
- declare compatibility with WordPress 6.8

## Testing
- `php -l panopress.php`
- `php -l includes/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c438f02e74832c95bff416b6afd2b6